### PR TITLE
Docs: upgrade to MkDocs 1.6.x and mkdocs_ipynb; fix gh-deploy

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,21 +1,42 @@
- name: Publish docs via GitHub
- on:
-   push:
-     branches:
-       - main
+name: Publish docs via GitHub
+on:
+  push:
+    branches: [ "main" ]
+  workflow_dispatch:
 
- jobs:
-   build:
-     name: Deploy docs
-     runs-on: ubuntu-latest
-     steps:
-       - uses: actions/checkout@v3
-       - uses: actions/setup-python@v4
-         with:
-           python-version: 3.9
-       - name: run requirements file
-         run:  pip install -r requirements.txt 
-       - name: Deploy docs
-         run: mkdocs gh-deploy --force
-         env:
-           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Deploy docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install deps
+        run: pip install -r requirements.txt
+
+      - name: Show versions
+        run: |
+          python -V
+          pip show mkdocs mkdocs-material mkdocs_ipynb || true
+          mkdocs --version || true
+
+      - name: Configure git user
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Deploy docs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: mkdocs gh-deploy --force --clean

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -104,6 +104,4 @@ plugins:
     - search
     - mkdocstrings
     - git-revision-date
-    - mkdocs-jupyter:
-          include_source: True
-          ignore_h1_titles: True
+    - ipynb

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,8 +12,8 @@ twine
 watchdog
 wheel
 mkdocs-git-revision-date-plugin 
-mkdocs-jupyter 
-mkdocs-material 
+mkdocs-material
+mkdocs_ipynb
 mkdocs-pdf-export-plugin
 mkdocstrings 
 mkdocstrings-crystal
@@ -22,7 +22,7 @@ mkdocstrings-python-legacy
 # Requirements for core
 jinja2>=3.0
 markdown>=3.2
-mkdocs>=1.4.2
+mkdocs>=1.6.1
 mkdocs-material-extensions>=1.1
 pygments>=2.14
 pymdown-extensions>=9.9.1


### PR DESCRIPTION
- Upgrades to MkDocs >=1.6.1 and replaces mkdocs-jupyter with mkdocs_ipynb for notebook rendering.
- Updates GH Actions to install from requirements, print versions, and deploy with built-in GITHUB_TOKEN + `contents: write`.
- Result: `mkdocs gh-deploy` runs successfully on modern MkDocs releases.


------
https://chatgpt.com/codex/tasks/task_e_68e03c0738d88325a6c9a9254bafdbe4